### PR TITLE
Change TokenType from const enum to enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ const formatted = markify('*bold text with _italic_ *', {
 // Result: <span class="a">bold text with <span class="u">italic</span> </span>
 ```
 
-(Note: If you don't use TypeScript, you can use the exported constants
-`TOKEN_TYPE_(ASTERISK|UNDERSCORE|TILDE)` instead.)
-
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,18 @@ export interface Token {
     value?: string;
 }
 
-// Re-export consts above for non-TS consumers
+// Deprecated re-exports for non-TS consumers
+/**
+ * @deprecated use {@link TokenType.Asterisk} intead
+ */
 export const TOKEN_TYPE_ASTERISK = TokenType.Asterisk;
+/**
+ * @deprecated use {@link TokenType.Underscore} intead
+ */
 export const TOKEN_TYPE_UNDERSCORE = TokenType.Underscore;
+/**
+ * @deprecated use {@link TokenType.Tilde} intead
+ */
 export const TOKEN_TYPE_TILDE = TokenType.Tilde;
 
 // The markup characters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@
  * at your option.
  */
 
-export const enum TokenType {
+export enum TokenType {
     Text,
     Newline,
     Asterisk,


### PR DESCRIPTION
This way non-TS consumers can use the type directly.

The constants have been deprecated.